### PR TITLE
Implement get_resource_reader method in rewrite's loader

### DIFF
--- a/tests/test_dessert.py
+++ b/tests/test_dessert.py
@@ -148,3 +148,18 @@ def source_filename_fx(request, source):
         f.write(source)
 
     return filename
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="importlib.resources.files was introduced in 3.9",
+)
+def test_load_resource_via_files_with_rewrite() -> None:
+    package_dir = mkdtemp()
+
+    with open(os.path.join(package_dir, '__init__.py'), 'w') as init_file:
+        init_file.write("""from importlib.resources import files
+assert files(__package__).exists()""")
+
+    with dessert.rewrite_assertions_context():
+        emport.import_file(os.path.join(package_dir, '__init__.py'))


### PR DESCRIPTION
The issue in  #25 is that AssertionRewritingHook doesn't implement get_resource_reader (from PEP302), I implemented the method like in [pytest](https://github.com/pytest-dev/pytest/blob/main/src/_pytest/assertion/rewrite.py#L292)